### PR TITLE
A group of minor fixes

### DIFF
--- a/src/AbstractRateLimiter.php
+++ b/src/AbstractRateLimiter.php
@@ -43,6 +43,14 @@ abstract class AbstractRateLimiter implements RateLimiterInterface
     /**
      * {@inheritdoc}
      */
+    public function setLimit(int $limit)
+    {
+        $this->limit = $limit;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getLimit() : int
     {
         return $this->limit;
@@ -88,7 +96,7 @@ abstract class AbstractRateLimiter implements RateLimiterInterface
      */
     public function getResetAt(string $key) : int
     {
-        return time() + $this->ttl($key);
+        return (int)ceil(microtime(true) + $this->ttl($key));
     }
 
     protected function getCurrent(string $key) : int
@@ -102,5 +110,5 @@ abstract class AbstractRateLimiter implements RateLimiterInterface
 
     abstract protected function increment(string $key);
 
-    abstract protected function ttl(string $key) : int;
+    abstract protected function ttl(string $key) : float;
 }

--- a/src/Middleware/Identity/IpAddressOrUserIdentityResolver.php
+++ b/src/Middleware/Identity/IpAddressOrUserIdentityResolver.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This file is part of the Rate Limit package.
+ *
+ * Copyright (c) Nikola Posa
+ *
+ * For full copyright and license information, please refer to the LICENSE file,
+ * located at the package root folder.
+ */
+
+declare(strict_types=1);
+
+namespace RateLimit\Middleware\Identity;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * @author Vassilis Poursalidis <poursal@gmail.com>
+ */
+final class IpAddressOrUserIdentityResolver extends AbstractIdentityResolver
+{
+    const IP_KEY_PREFIX   = 'rlimit-ip-';
+    const USER_KEY_PREFIX = 'rlimit-id-';
+
+    /**
+     * @var array
+     */
+    protected $loadBalancers;
+
+    public function __construct(array $loadBalancers = [])
+    {
+        $this->loadBalancers = $loadBalancers;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIdentity(RequestInterface $request) : string
+    {
+        if (!$request instanceof ServerRequestInterface) {
+            return self::getDefaultIdentity($request);
+        }
+
+        $serverParams = $request->getServerParams();
+        $authUserId   = $request->getAttribute('authUserId');
+
+        if ( !empty($authUserId) ) {
+            return USER_KEY_PREFIX . $authUserId;
+        }
+
+        if ( !empty($serverParams['REMOTE_ADDR']) && in_array($serverParams['REMOTE_ADDR'], $this->loadBalancers) ) {
+            if (array_key_exists('HTTP_CLIENT_IP', $serverParams)) {
+                return self::IP_KEY_PREFIX . $serverParams['HTTP_CLIENT_IP'];
+            }
+
+            if (array_key_exists('HTTP_X_FORWARDED_FOR', $serverParams)) {
+                return self::IP_KEY_PREFIX . $serverParams['HTTP_X_FORWARDED_FOR'];
+            }
+        }
+
+        return $serverParams['REMOTE_ADDR'] ? (self::IP_KEY_PREFIX . $serverParams['REMOTE_ADDR']) : self::getDefaultIdentity($request);
+    }
+}

--- a/src/Middleware/Identity/IpAddressOrUserIdentityResolver.php
+++ b/src/Middleware/Identity/IpAddressOrUserIdentityResolver.php
@@ -28,9 +28,15 @@ final class IpAddressOrUserIdentityResolver extends AbstractIdentityResolver
      */
     protected $loadBalancers;
 
-    public function __construct(array $loadBalancers = [])
+    /**
+     * @var string
+     */
+    protected $authKeyName;
+
+    public function __construct(array $loadBalancers = [], string authKeyName = 'authUserId')
     {
         $this->loadBalancers = $loadBalancers;
+        $this->authKeyName   = $authKeyName;
     }
 
     /**
@@ -43,7 +49,7 @@ final class IpAddressOrUserIdentityResolver extends AbstractIdentityResolver
         }
 
         $serverParams = $request->getServerParams();
-        $authUserId   = $request->getAttribute('authUserId');
+        $authUserId   = $request->getAttribute($this->authKeyName);
 
         if ( !empty($authUserId) ) {
             return USER_KEY_PREFIX . $authUserId;

--- a/src/Middleware/Identity/IpAddressOrUserIdentityResolver.php
+++ b/src/Middleware/Identity/IpAddressOrUserIdentityResolver.php
@@ -33,7 +33,7 @@ final class IpAddressOrUserIdentityResolver extends AbstractIdentityResolver
      */
     protected $authKeyName;
 
-    public function __construct(array $loadBalancers = [], string authKeyName = 'authUserId')
+    public function __construct(array $loadBalancers = [], string $authKeyName = 'authUserId')
     {
         $this->loadBalancers = $loadBalancers;
         $this->authKeyName   = $authKeyName;

--- a/src/RateLimiterInterface.php
+++ b/src/RateLimiterInterface.php
@@ -20,6 +20,13 @@ use RateLimit\Exception\RateLimitExceededException;
 interface RateLimiterInterface
 {
     /**
+     * @param int $limit
+     *
+     * @return void
+     */
+    public function setLimit(int $limit);
+
+    /**
      * @return int
      */
     public function getLimit() : int;

--- a/src/RedisRateLimiter.php
+++ b/src/RedisRateLimiter.php
@@ -52,8 +52,15 @@ final class RedisRateLimiter extends AbstractRateLimiter
         $this->redis->incr($key);
     }
 
-    protected function ttl(string $key) : int
+    protected function ttl(string $key) : float
     {
-        return max((int) ceil($this->redis->pttl($key) / 1000), 0);
+        $ttl = $this->redis->pttl($key);
+        if ( $ttl===-1 ) {
+            // The key was created without an expiration date
+            $this->redis->expire($key, $this->window);
+            $ttl = $this->window*1000;
+        }
+
+        return max($ttl / 1000, 0.0);
     }
 }


### PR DESCRIPTION
Fixes the following:

1. Can update the limit externally (i.e. increase the limit for authenticated users)
2. Fix the reset-at wave problems by going to microseconds
3. Fix marginal bug in HIT, where by increment an expired key it creates a key that never expires
4. Be able to set the trusted LB that are allowed to send the FORWARD headers
5. Be able to switch between IP and authenticated user on the Identity Resolver