### PR TITLE
LimitExceeded exception now contains an instance of Status instance

### DIFF
--- a/src/Exception/LimitExceeded.php
+++ b/src/Exception/LimitExceeded.php
@@ -5,32 +5,38 @@ declare(strict_types=1);
 namespace RateLimit\Exception;
 
 use RateLimit\Rate;
+use RateLimit\Status;
 use RuntimeException;
 
 final class LimitExceeded extends RuntimeException
 {
-    /** @var string */
-    protected $identifier;
-
     /** @var Rate */
     protected $rate;
 
-    public static function for(string $identifier, Rate $rate): self
+    /** @var Status */
+    protected $status;
+
+    public static function for(Status $status, Rate $rate): self
     {
-        $exception = new self("Limit of has been exceeded by identifier: $identifier");
-        $exception->identifier = $identifier;
+        $exception = new self("Limit of has been exceeded by identifier: {$status->getIdentifier()}");
         $exception->rate = $rate;
+        $exception->status = $status;
 
         return $exception;
     }
 
     public function getIdentifier(): string
     {
-        return $this->identifier;
+        return $this->status->getIdentifier();
     }
 
     public function getRate(): Rate
     {
         return $this->rate;
+    }
+
+    public function getStatus(): Status
+    {
+        return $this->status;
     }
 }

--- a/src/RedisRateLimiter.php
+++ b/src/RedisRateLimiter.php
@@ -23,15 +23,11 @@ final class RedisRateLimiter implements RateLimiter, SilentRateLimiter
 
     public function limit(string $identifier, Rate $rate): void
     {
-        $key = $this->key($identifier, $rate->getInterval());
+        $status = $this->limitSilently($identifier, $rate);
 
-        $current = $this->getCurrent($key);
-
-        if ($current >= $rate->getOperations()) {
-            throw LimitExceeded::for($identifier, $rate);
+        if ($status->limitExceeded()) {
+            throw LimitExceeded::for($status, $rate);
         }
-
-        $this->updateCounter($key, $rate->getInterval());
     }
 
     public function limitSilently(string $identifier, Rate $rate): Status

--- a/tests/RateLimiterTest.php
+++ b/tests/RateLimiterTest.php
@@ -79,7 +79,6 @@ abstract class RateLimiterTest extends TestCase
         $rate = Rate::perHour(1);
 
         $rateLimiter->limitSilently($identifier, $rate);
-        $rateLimiter->limitSilently($identifier, $rate);
         $status = $rateLimiter->limitSilently($identifier, $rate);
 
         $this->assertTrue($status->limitExceeded());
@@ -99,7 +98,7 @@ abstract class RateLimiterTest extends TestCase
 
         $identifier = 'test';
         $rate = Rate::perMinute(10);
-        
+
         $status = $rateLimiter->limitSilently($identifier, $rate);
 
         $this->assertSame($identifier, $status->getIdentifier());

--- a/tests/RateLimiterTest.php
+++ b/tests/RateLimiterTest.php
@@ -9,6 +9,7 @@ use RateLimit\Exception\LimitExceeded;
 use RateLimit\Rate;
 use RateLimit\RateLimiter;
 use RateLimit\SilentRateLimiter;
+use RateLimit\Status;
 
 abstract class RateLimiterTest extends TestCase
 {
@@ -33,6 +34,9 @@ abstract class RateLimiterTest extends TestCase
             $this->assertSame("Limit of has been exceeded by identifier: $identifier", $exception->getMessage());
             $this->assertSame($identifier, $exception->getIdentifier());
             $this->assertSame($rate, $exception->getRate());
+            $this->assertInstanceOf(Status::class, $exception->getStatus());
+            $this->assertTrue($exception->getStatus()->limitExceeded());
+            $this->assertSame(0, $exception->getStatus()->getRemainingAttempts());
         }
     }
 
@@ -55,6 +59,8 @@ abstract class RateLimiterTest extends TestCase
             $this->fail('Limit should have been reached');
         } catch (LimitExceeded $exception) {
             $this->assertSame($identifier, $exception->getIdentifier());
+            $this->assertTrue($exception->getStatus()->limitExceeded());
+            $this->assertSame(0, $exception->getStatus()->getRemainingAttempts());
         }
     }
 


### PR DESCRIPTION
When using the exception, it was impossible to know how long to wait before a new request could be executed. Now, the exception has an instance of `Status' which can be used to wait for the right time. The use of silent limitation is not suitable in all cases and forces the developer to create a new exception to get this information.

Use cases
---

```php
<?php

use Illuminate\Http\Client\RequestException;
use Illuminate\Support\Facades\Http;
use RateLimit\Rate;
use RateLimit\RedisRateLimiter;
use Redis;

$rateLimiter = new RedisRateLimiter(new Redis());

while (true) {
	$token  = 'my-identifier';
	$status = $rateLimiter->limitSilently($token, Rate::perSecond(1));

	// If the limit is reached, wait until the token is available again.
	if ($status->limitExceeded()) {
		sleep($status->getResetAt()->getTimestamp() - now()->timestamp);
	}

	try {
		$data = Http::withToken($token)->get("http://acme/api/posts");
		// ...
	}

	catch (RequestException $e) {
		// ...
	}
}
```

```php
<?php

use Illuminate\Http\Client\RequestException;
use Illuminate\Support\Facades\Http;
use RateLimit\Exception\LimitExceeded;
use RateLimit\Rate;
use RateLimit\RedisRateLimiter;
use Redis;

$rateLimiter = new RedisRateLimiter(new Redis());

while (true) {
	try {
		$token  = 'my-identifier';
		$status = $rateLimiter->limit($token, Rate::perSecond(1));

		$data = Http::withToken($token)->get("http://acme/api/posts");
		// ...
	}

	catch (RequestException $e) {
		// ...
	}
	
	catch (LimitExceeded $e) {
		sleep($e->status->getResetAt()->getTimestamp() - now()->timestamp);
	}
}
```