### PR TITLE
throw native exceptions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.1",
         "phpstan/phpstan": "^0.12.10",
-        "phpstan/phpstan-beberlei-assert": "^0.12.2",
         "phpstan/phpstan-phpunit": "^0.12.6",
         "phpunit/phpunit": "^8.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.2",
-        "beberlei/assert": "^3.2"
+        "php": "^7.2"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.1",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,5 +9,4 @@ parameters:
         - '~Method [a-zA-Z0-9\\_]+Rate::[a-zA-Z0-9_]*\(\) has no return typehint specified.~'
 
 includes:
-    - vendor/phpstan/phpstan-beberlei-assert/extension.neon
     - vendor/phpstan/phpstan-phpunit/extension.neon

--- a/src/Rate.php
+++ b/src/Rate.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace RateLimit;
 
-use Assert\Assertion;
-
 class Rate
 {
     /** @var int */
@@ -16,8 +14,13 @@ class Rate
 
     final protected function __construct(int $operations, int $interval)
     {
-        Assertion::greaterThan($operations, 0, 'Quota must be greater than zero');
-        Assertion::greaterThan($interval, 0, 'Seconds interval must be greater than zero');
+        if ($operations <= 0) {
+            throw new \InvalidArgumentException('Quota must be greater than zero');
+        }
+
+        if ($interval <= 0) {
+            throw new \InvalidArgumentException('Seconds interval must be greater than zero');
+        }
 
         $this->operations = $operations;
         $this->interval = $interval;


### PR DESCRIPTION
beberlei/assert is 208KB for two checks and raising \InvalidArgumentException (with some extra data that will hardly ever be used)

Just check lower limit and raise native php exceptions