### PR TITLE
Fix: Reduce visibility

### DIFF
--- a/src/Exception/LimitExceeded.php
+++ b/src/Exception/LimitExceeded.php
@@ -10,10 +10,10 @@ use RuntimeException;
 final class LimitExceeded extends RuntimeException implements RateLimitException
 {
     /** @var string */
-    protected $identifier;
+    private $identifier;
 
     /** @var Rate */
-    protected $rate;
+    private $rate;
 
     public static function for(string $identifier, Rate $rate): self
     {


### PR DESCRIPTION
This PR

* [x] reduces the visibility of fields in a `final` class from `protected` to `private`