### PR TITLE
Rate as configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ use RateLimit\Rate;
 use RateLimit\RedisRateLimiter;
 use Redis;
 
-$rateLimiter = new RedisRateLimiter(new Redis());
+$rateLimiter = new RedisRateLimiter(Rate::perMinute(100), new Redis());
 
 $apiKey = 'abc123';
 
 try {
-    $rateLimiter->limit($apiKey, Rate::perMinute(100));
+    $rateLimiter->limit($apiKey);
     
     //on success
 } catch (LimitExceeded $exception) {
@@ -48,10 +48,10 @@ use RateLimit\Rate;
 use RateLimit\RedisRateLimiter;
 use Redis;
 
-$rateLimiter = new RedisRateLimiter(new Redis());
+$rateLimiter = new RedisRateLimiter(Rate::perMinute(100), new Redis());
 
 $ipAddress = '192.168.1.2';
-$status = $rateLimiter->limitSilently($ipAddress, Rate::perMinute(100));
+$status = $rateLimiter->limitSilently($ipAddress);
 
 echo $status->getRemainingAttempts(); //99
 ```

--- a/src/ConfigurableRateLimiter.php
+++ b/src/ConfigurableRateLimiter.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RateLimit;
+
+abstract class ConfigurableRateLimiter
+{
+    /** @var Rate */
+    protected $rate;
+
+    public function __construct(Rate $rate)
+    {
+        $this->rate = $rate;
+    }
+}

--- a/src/PredisRateLimiter.php
+++ b/src/PredisRateLimiter.php
@@ -10,7 +10,7 @@ use function ceil;
 use function max;
 use function time;
 
-final class PredisRateLimiter implements RateLimiter, SilentRateLimiter
+final class PredisRateLimiter extends ConfigurableRateLimiter implements RateLimiter, SilentRateLimiter
 {
     /** @var ClientInterface */
     private $predis;
@@ -18,46 +18,47 @@ final class PredisRateLimiter implements RateLimiter, SilentRateLimiter
     /** @var string */
     private $keyPrefix;
 
-    public function __construct(ClientInterface $predis, string $keyPrefix = '')
+    public function __construct(Rate $rate, ClientInterface $predis, string $keyPrefix = '')
     {
+        parent::__construct($rate);
         $this->predis = $predis;
         $this->keyPrefix = $keyPrefix;
     }
 
-    public function limit(string $identifier, Rate $rate): void
+    public function limit(string $identifier): void
     {
-        $key = $this->key($identifier, $rate->getInterval());
+        $key = $this->key($identifier);
 
         $current = $this->getCurrent($key);
 
-        if ($current >= $rate->getOperations()) {
-            throw LimitExceeded::for($identifier, $rate);
+        if ($current >= $this->rate->getOperations()) {
+            throw LimitExceeded::for($identifier, $this->rate);
         }
 
-        $this->updateCounter($key, $rate->getInterval());
+        $this->updateCounter($key);
     }
 
-    public function limitSilently(string $identifier, Rate $rate): Status
+    public function limitSilently(string $identifier): Status
     {
-        $key = $this->key($identifier, $rate->getInterval());
+        $key = $this->key($identifier);
 
         $current = $this->getCurrent($key);
 
-        if ($current <= $rate->getOperations()) {
-            $current = $this->updateCounter($key, $rate->getInterval());
+        if ($current <= $this->rate->getOperations()) {
+            $current = $this->updateCounter($key);
         }
 
         return Status::from(
             $identifier,
             $current,
-            $rate->getOperations(),
+            $this->rate->getOperations(),
             time() + $this->ttl($key)
         );
     }
 
-    private function key(string $identifier, int $interval): string
+    private function key(string $identifier): string
     {
-        return "{$this->keyPrefix}{$identifier}:$interval";
+        return "{$this->keyPrefix}{$identifier}:{$this->rate->getInterval()}";
     }
 
     private function getCurrent(string $key): int
@@ -65,12 +66,12 @@ final class PredisRateLimiter implements RateLimiter, SilentRateLimiter
         return (int) $this->predis->get($key);
     }
 
-    private function updateCounter(string $key, int $interval): int
+    private function updateCounter(string $key): int
     {
         $current = $this->predis->incr($key);
 
         if ($current === 1) {
-            $this->predis->expire($key, $interval);
+            $this->predis->expire($key, $this->rate->getInterval());
         }
 
         return $current;

--- a/src/RateLimiter.php
+++ b/src/RateLimiter.php
@@ -11,5 +11,5 @@ interface RateLimiter
     /**
      * @throws LimitExceeded
      */
-    public function limit(string $identifier, Rate $rate): void;
+    public function limit(string $identifier): void;
 }

--- a/src/SilentRateLimiter.php
+++ b/src/SilentRateLimiter.php
@@ -6,5 +6,5 @@ namespace RateLimit;
 
 interface SilentRateLimiter
 {
-    public function limitSilently(string $identifier, Rate $rate): Status;
+    public function limitSilently(string $identifier): Status;
 }

--- a/tests/ApcuRateLimiterTest.php
+++ b/tests/ApcuRateLimiterTest.php
@@ -6,15 +6,16 @@ namespace RateLimit\Tests;
 
 use RateLimit\ApcuRateLimiter;
 use RateLimit\Exception\CannotUseRateLimiter;
+use RateLimit\Rate;
 use RateLimit\RateLimiter;
 use function apcu_clear_cache;
 
 class ApcuRateLimiterTest extends RateLimiterTest
 {
-    protected function getRateLimiter(): RateLimiter
+    protected function getRateLimiter(Rate $rate): RateLimiter
     {
         try {
-            $rateLimiter = new ApcuRateLimiter();
+            $rateLimiter = new ApcuRateLimiter($rate);
         } catch (CannotUseRateLimiter $exception) {
             $this->markTestSkipped($exception->getMessage());
         }

--- a/tests/InMemoryRateLimiterTest.php
+++ b/tests/InMemoryRateLimiterTest.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace RateLimit\Tests;
 
 use RateLimit\InMemoryRateLimiter;
+use RateLimit\Rate;
 use RateLimit\RateLimiter;
 
 class InMemoryRateLimiterTest extends RateLimiterTest
 {
-    protected function getRateLimiter(): RateLimiter
+    protected function getRateLimiter(Rate $rate): RateLimiter
     {
-        return new InMemoryRateLimiter();
+        return new InMemoryRateLimiter($rate);
     }
 }

--- a/tests/MemcachedRateLimiterTest.php
+++ b/tests/MemcachedRateLimiterTest.php
@@ -6,12 +6,13 @@ namespace RateLimit\Tests;
 
 use Memcached;
 use RateLimit\MemcachedRateLimiter;
+use RateLimit\Rate;
 use RateLimit\RateLimiter;
 use function extension_loaded;
 
 class MemcachedRateLimiterTest extends RateLimiterTest
 {
-    protected function getRateLimiter(): RateLimiter
+    protected function getRateLimiter(Rate $rate): RateLimiter
     {
         if (!extension_loaded('memcached')) {
             $this->markTestSkipped('Memcached extension not loaded.');
@@ -26,6 +27,6 @@ class MemcachedRateLimiterTest extends RateLimiterTest
             $this->markTestSkipped('Cannot connect to Memcached.');
         }
 
-        return new MemcachedRateLimiter($memcached);
+        return new MemcachedRateLimiter($rate, $memcached);
     }
 }

--- a/tests/PredisRateLimiterTest.php
+++ b/tests/PredisRateLimiterTest.php
@@ -6,12 +6,13 @@ namespace RateLimit\Tests;
 
 use Predis\Client;
 use RateLimit\PredisRateLimiter;
+use RateLimit\Rate;
 use RateLimit\RateLimiter;
 use function class_exists;
 
 class PredisRateLimiterTest extends RateLimiterTest
 {
-    protected function getRateLimiter(): RateLimiter
+    protected function getRateLimiter(Rate $rate): RateLimiter
     {
         if (!class_exists('Predis\Client')) {
             $this->markTestSkipped('Predis library is not available');
@@ -26,6 +27,6 @@ class PredisRateLimiterTest extends RateLimiterTest
 
         $predis->flushdb();
 
-        return new PredisRateLimiter($predis);
+        return new PredisRateLimiter($rate, $predis);
     }
 }

--- a/tests/RedisRateLimiterTest.php
+++ b/tests/RedisRateLimiterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace RateLimit\Tests;
 
+use RateLimit\Rate;
 use RateLimit\RateLimiter;
 use RateLimit\RedisRateLimiter;
 use Redis;
@@ -11,7 +12,7 @@ use function extension_loaded;
 
 class RedisRateLimiterTest extends RateLimiterTest
 {
-    protected function getRateLimiter(): RateLimiter
+    protected function getRateLimiter(Rate $rate): RateLimiter
     {
         if (!extension_loaded('redis')) {
             $this->markTestSkipped('Redis extension not loaded.');
@@ -27,6 +28,6 @@ class RedisRateLimiterTest extends RateLimiterTest
 
         $redis->flushDB();
 
-        return new RedisRateLimiter($redis);
+        return new RedisRateLimiter($rate, $redis);
     }
 }


### PR DESCRIPTION
Remove `Rate` parameter from `RateLimiter` and `SilentRateLimiter` interfaces.

This decision was prompted by the most common Rate Limiter use scenarios, where unlike identifier parameter, Rate parameter is static, it never changes once rate limiting clause is put in place. This is nicely illustrated in the example of a [RateLimitMiddleware](https://github.com/nikolaposa/rate-limit-middleware/blob/master/src/RateLimitMiddleware.php#L36), which in addition to the RateLimiter itself needs to be constructed with a specific Rate for which it should run.

Rate really is a configuration, not a dynamic parameter to be passed in runtime. In practice, this library is used in a way that multiplle rate limiting strategies are registered with the Dependency Injection Container of the project, for example:

```php
$container->set('rate_limiter.web', new RedisRateLimiter(Rate::perMinute(100), $container->get('redis'));
$container->set('rate_limiter.api', new RedisRateLimiter(Rate::perSecond(10), $container->get('redis'));
```