### PR TITLE
PHP 7.4 migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.2
+          - 7.4
 
     steps:
       - name: Checkout
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.2
+          - 7.4
 
     steps:
       - name: Checkout
@@ -107,8 +107,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.2
-          - 7.3
           - 7.4
           - 8.0
 
@@ -160,7 +158,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.2
+          - 7.4
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "beberlei/assert": "^3.2"
     },
     "require-dev": {

--- a/src/ApcuRateLimiter.php
+++ b/src/ApcuRateLimiter.php
@@ -17,8 +17,7 @@ use function time;
 
 final class ApcuRateLimiter extends ConfigurableRateLimiter implements RateLimiter, SilentRateLimiter
 {
-    /** @var string */
-    private $keyPrefix;
+    private string $keyPrefix;
 
     public function __construct(Rate $rate, string $keyPrefix = '')
     {

--- a/src/ConfigurableRateLimiter.php
+++ b/src/ConfigurableRateLimiter.php
@@ -6,8 +6,7 @@ namespace RateLimit;
 
 abstract class ConfigurableRateLimiter
 {
-    /** @var Rate */
-    protected $rate;
+    protected Rate $rate;
 
     public function __construct(Rate $rate)
     {

--- a/src/Exception/LimitExceeded.php
+++ b/src/Exception/LimitExceeded.php
@@ -9,11 +9,8 @@ use RuntimeException;
 
 final class LimitExceeded extends RuntimeException implements RateLimitException
 {
-    /** @var string */
-    private $identifier;
-
-    /** @var Rate */
-    private $rate;
+    private string $identifier;
+    private Rate $rate;
 
     public static function for(string $identifier, Rate $rate): self
     {

--- a/src/InMemoryRateLimiter.php
+++ b/src/InMemoryRateLimiter.php
@@ -10,8 +10,7 @@ use function time;
 
 final class InMemoryRateLimiter extends ConfigurableRateLimiter implements RateLimiter, SilentRateLimiter
 {
-    /** @var array */
-    private $store = [];
+    private array $store = [];
 
     public function limit(string $identifier): void
     {

--- a/src/MemcachedRateLimiter.php
+++ b/src/MemcachedRateLimiter.php
@@ -15,11 +15,8 @@ final class MemcachedRateLimiter extends ConfigurableRateLimiter implements Rate
 {
     private const MEMCACHED_SECONDS_LIMIT = 2592000; // 30 days in seconds
 
-    /** @var Memcached */
-    private $memcached;
-
-    /** @var string */
-    private $keyPrefix;
+    private Memcached $memcached;
+    private string $keyPrefix;
 
     public function __construct(Rate $rate, Memcached $memcached, string $keyPrefix = '')
     {

--- a/src/PredisRateLimiter.php
+++ b/src/PredisRateLimiter.php
@@ -12,11 +12,8 @@ use function time;
 
 final class PredisRateLimiter extends ConfigurableRateLimiter implements RateLimiter, SilentRateLimiter
 {
-    /** @var ClientInterface */
-    private $predis;
-
-    /** @var string */
-    private $keyPrefix;
+    private ClientInterface $predis;
+    private string $keyPrefix;
 
     public function __construct(Rate $rate, ClientInterface $predis, string $keyPrefix = '')
     {

--- a/src/Rate.php
+++ b/src/Rate.php
@@ -8,11 +8,8 @@ use Assert\Assertion;
 
 class Rate
 {
-    /** @var int */
-    protected $operations;
-
-    /** @var int */
-    protected $interval;
+    protected int $operations;
+    protected int $interval;
 
     final protected function __construct(int $operations, int $interval)
     {

--- a/src/RedisRateLimiter.php
+++ b/src/RedisRateLimiter.php
@@ -12,11 +12,8 @@ use function time;
 
 final class RedisRateLimiter extends ConfigurableRateLimiter implements RateLimiter, SilentRateLimiter
 {
-    /** @var Redis */
-    private $redis;
-
-    /** @var string */
-    private $keyPrefix;
+    private Redis $redis;
+    private string $keyPrefix;
 
     public function __construct(Rate $rate, Redis $redis, string $keyPrefix = '')
     {

--- a/src/Status.php
+++ b/src/Status.php
@@ -9,20 +9,11 @@ use function max;
 
 class Status
 {
-    /** @var string */
-    protected $identifier;
-
-    /** @var bool */
-    protected $success;
-
-    /** @var int */
-    protected $limit;
-
-    /** @var int */
-    protected $remainingAttempts;
-
-    /** @var DateTimeImmutable */
-    protected $resetAt;
+    protected string $identifier;
+    protected bool $success;
+    protected int $limit;
+    protected int $remainingAttempts;
+    protected DateTimeImmutable $resetAt;
 
     final protected function __construct(string $identifier, bool $success, int $limit, int $remainingAttempts, DateTimeImmutable $resetAt)
     {


### PR DESCRIPTION
Set PHP 7.4 as a minimum requirement and adopt typed properties feature throughout the code.