### PR TITLE
Require PHP 8.1+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.4
+          - 8.1
 
     steps:
       - name: Checkout
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.4
+          - 8.1
 
     steps:
       - name: Checkout
@@ -107,8 +107,9 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.4
-          - 8.0
+          - 8.1
+          - 8.2
+          - 8.3
 
     steps:
       - name: Checkout
@@ -158,11 +159,13 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - 7.4
+          - 8.1
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 10
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -186,10 +189,11 @@ jobs:
       - name: Install dependencies
         run: composer install --no-interaction
 
-      - name: Collect code coverage
+      - name: Download code coverage reporter
+        run: composer global require scrutinizer/ocular
+
+      - name: Collect code coverage with phpunit/phpunit and
         run: vendor/bin/phpunit --coverage-text --coverage-clover=clover.xml
 
       - name: Upload code coverage
-        run: |
-          wget https://scrutinizer-ci.com/ocular.phar
-          php ocular.phar code-coverage:upload --format=php-clover clover.xml
+        run: ~/.composer/vendor/bin/ocular code-coverage:upload --format=php-clover clover.xml

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -2,10 +2,11 @@
 
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
-    ->exclude('vendor')
-;
+    ->exclude('vendor');
 
-return PhpCsFixer\Config::create()
+return (new PhpCsFixer\Config())
+    ->setFinder($finder)
+    ->setRiskyAllowed(true)
     ->setRules([
         '@PSR2' => true,
         'array_syntax' => ['syntax' => 'short'],
@@ -27,7 +28,4 @@ return PhpCsFixer\Config::create()
         ],
         'phpdoc_line_span' => ['property' => 'single'],
         'return_type_declaration' => ['space_before' => 'none'],
-])
-    ->setRiskyAllowed(true)
-    ->setFinder($finder)
-;
+]);

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,17 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.1",
         "beberlei/assert": "^3.2"
     },
     "require-dev": {
         "ext-apcu": ">=5.1.12",
         "ext-redis": "*",
-        "friendsofphp/php-cs-fixer": "^2.17",
-        "phpstan/phpstan": "^0.12.10",
-        "phpstan/phpstan-beberlei-assert": "^0.12.2",
-        "phpstan/phpstan-phpunit": "^0.12.6",
-        "phpunit/phpunit": "^8.0",
+        "friendsofphp/php-cs-fixer": "3.44",
+        "phpstan/phpstan": "^1.10",
+        "phpstan/phpstan-beberlei-assert": "^1.1",
+        "phpstan/phpstan-phpunit": "^1.3",
+        "phpunit/phpunit": "^10.5",
         "predis/predis": "^1.1"
     },
     "suggest": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,8 +5,6 @@ parameters:
         - tests
     checkMissingIterableValueType: false
     ignoreErrors:
-        - '~Method [a-zA-Z0-9\\_]+::from[a-zA-Z0-9_]*\(\) has no return typehint specified.~'
-        - '~Method [a-zA-Z0-9\\_]+Rate::[a-zA-Z0-9_]*\(\) has no return typehint specified.~'
         - message: '~Strict comparison using === between int and false will always evaluate to false.~'
           path: 'src/ApcuRateLimiter.php'
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <phpunit
-    bootstrap="./vendor/autoload.php"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+    bootstrap="vendor/autoload.php"
     colors="true"
 >
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+    </source>
+    <coverage/>
     <testsuites>
-        <testsuite name="Rate Limit tests">
+        <testsuite name="unit">
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+    <php>
+        <ini name="error_reporting" value="E_ALL"/>
+    </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,7 @@
     <testsuites>
         <testsuite name="unit">
             <directory>./tests</directory>
+            <exclude>./tests/RateLimiterTest.php</exclude>
         </testsuite>
     </testsuites>
     <php>

--- a/src/Rate.php
+++ b/src/Rate.php
@@ -20,27 +20,27 @@ class Rate
         $this->interval = $interval;
     }
 
-    public static function perSecond(int $operations)
+    public static function perSecond(int $operations): static
     {
         return new static($operations, 1);
     }
 
-    public static function perMinute(int $operations)
+    public static function perMinute(int $operations): static
     {
         return new static($operations, 60);
     }
 
-    public static function perHour(int $operations)
+    public static function perHour(int $operations): static
     {
         return new static($operations, 3600);
     }
 
-    public static function perDay(int $operations)
+    public static function perDay(int $operations): static
     {
         return new static($operations, 86400);
     }
 
-    public static function custom(int $operations, int $interval)
+    public static function custom(int $operations, int $interval): static
     {
         return new static($operations, $interval);
     }

--- a/src/RedisRateLimiter.php
+++ b/src/RedisRateLimiter.php
@@ -65,7 +65,7 @@ final class RedisRateLimiter extends ConfigurableRateLimiter implements RateLimi
 
     private function updateCounter(string $key): int
     {
-        $current = $this->redis->incr($key);
+        $current = (int) $this->redis->incr($key);
 
         if ($current === 1) {
             $this->redis->expire($key, $this->rate->getInterval());

--- a/src/Status.php
+++ b/src/Status.php
@@ -24,7 +24,7 @@ class Status
         $this->resetAt = $resetAt;
     }
 
-    public static function from(string $identifier, int $current, int $limit, int $resetTime)
+    public static function from(string $identifier, int $current, int $limit, int $resetTime): static
     {
         return new static(
             $identifier,


### PR DESCRIPTION
### Proposed Changes
Set PHP 8.1 as minimum requirement. Drop support for PHP <= 8.0.