### PR TITLE
fix: explicitly declare nullable types for parameters defaulting to null

### DIFF
--- a/src/RuntimeConfigurableRateLimiter.php
+++ b/src/RuntimeConfigurableRateLimiter.php
@@ -13,7 +13,7 @@ final class RuntimeConfigurableRateLimiter extends ConfigurableRateLimiter imple
         parent::__construct(Rate::perSecond(1));
     }
 
-    public function limit(string $identifier, Rate $rate = null): void
+    public function limit(string $identifier, ?Rate $rate = null): void
     {
         if (!$this->rateLimiter instanceof RateLimiter) {
             throw new LogicException('Decorated Rate Limiter must implement RateLimiter interface');
@@ -26,7 +26,7 @@ final class RuntimeConfigurableRateLimiter extends ConfigurableRateLimiter imple
         $this->rateLimiter->limit($identifier);
     }
 
-    public function limitSilently(string $identifier, Rate $rate = null): Status
+    public function limitSilently(string $identifier, ?Rate $rate = null): Status
     {
         if (!$this->rateLimiter instanceof SilentRateLimiter) {
             throw new LogicException('Decorated Rate Limiter must implement SilentRateLimiter interface');


### PR DESCRIPTION
This PR resolves a PHP deprecation warning regarding implicit nullable parameters. In recent PHP versions, implicitly marking a parameter as nullable by giving it a default value of `null` is deprecated. Parameters that accept `null` must now be explicitly declared as nullable.

> Deprecated: RateLimit\RuntimeConfigurableRateLimiter::limit(): Implicitly marking parameter $rate as nullable is deprecated, the explicit nullable type must be used instead